### PR TITLE
Fix Canvas is not a constructor error bug

### DIFF
--- a/lib/graphics-canvas.js
+++ b/lib/graphics-canvas.js
@@ -44,7 +44,7 @@ var Graphics = function(width, height, border, padding, font, fontsize){
 		, top: this.border_size
 		, left: this.padding_width + this.quiet };
 
-	this.canvas = new Canvas(width, height);
+	this.canvas = new Canvas.Canvas(width, height);
 	this.ctx = this.canvas.getContext('2d');
 	this.fg = "#000";
 	this.bg = "#fff";
@@ -94,7 +94,7 @@ Graphics.prototype.rotate = function(angle){
 	var bounds = geo.getRotatedBounds(this.width, this.height, rad);
 	var img = new Image();
 	img.src = this.canvas.toBuffer();
-	var canvas = new Canvas(bounds.width, bounds.height);
+	var canvas = new Canvas.Canvas(bounds.width, bounds.height);
 	var ctx = canvas.getContext('2d');
 	ctx.translate(bounds.width * 0.5, bounds.height * 0.5);
 	ctx.rotate(rad);


### PR DESCRIPTION
the top level import in node-canvas no longer was a constructor function instead has a .Canvas property